### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Installation
 ====================
 
 + download newest version of library from releases section [Lib] or use it as cocoapods spec
-+ add these files to your project (drag&drop into xCode project)
++ add these files to your project (drag&drop into Xcode project)
 + make sure that you have added “-ObjC -all_load” to “other linker flags” (click at project root element, select “Build settings” tab, search for “other linker flags”)
 + <del>if you already have JSONKit.m file in your project, please remove it because of linker conflict</del> We switched to Apple's NSJSONSerialization so skip this step.
 + add QuartzCore to frameworks list


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
